### PR TITLE
Added fallback event listener for safari mobile <13.

### DIFF
--- a/docroot/themes/contrib/civic/civic-library/components/00-base/responsive/responsive.js
+++ b/docroot/themes/contrib/civic/civic-library/components/00-base/responsive/responsive.js
@@ -20,7 +20,13 @@ function CivicResponsive() {
     // Only proceed if this query was not processed previously.
     if (!(query in window.civicResponsive)) {
       window.civicResponsive[query] = window.matchMedia(query);
-      window.civicResponsive[query].addEventListener('change', this.mediaQueryChange.bind(this, breakpoint));
+      // Add fallback support for Safari 13.
+      const hasEventListener = (window.civicResponsive[query].addEventListener !== undefined);
+      if (hasEventListener) {
+        window.civicResponsive[query].addEventListener('change', this.mediaQueryChange.bind(this, breakpoint));
+      } else {
+        window.civicResponsive[query].addListener(this.mediaQueryChange.bind(this, breakpoint));
+      }
     }
     // Call event handler on init.
     this.mediaQueryChange(breakpoint, { matches: window.civicResponsive[query].matches });


### PR DESCRIPTION
### Background
Added fallback for mobile safari <13 which does not have `addEventListener`