### PR TITLE
[ONI-610] Fixed mobile layout and alignment.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme-library/components/03-organisms/content/content-layout--single-column-contained.twig
+++ b/docroot/themes/contrib/civictheme/civictheme-library/components/03-organisms/content/content-layout--single-column-contained.twig
@@ -14,7 +14,7 @@
      <div class="container">
        <div class="row">
         {% block content %}
-          <div class="civictheme-layout__content col-m-12 {{ modifier_class }}">
+          <div class="civictheme-layout__content col-m-12 col-xxs-12 {{ modifier_class }}">
             {{ content }}
           </div>
         {% endblock %}

--- a/docroot/themes/contrib/civictheme/civictheme-library/components/03-organisms/content/content.twig
+++ b/docroot/themes/contrib/civictheme/civictheme-library/components/03-organisms/content/content.twig
@@ -53,14 +53,14 @@
 
         {% if sidebar is not empty %}
           {% block sidebar %}
-            <aside class="civictheme-content__sidebar {% if has_sidebar %}col-m-3{% endif %}" role="complementary" {% if sidebar_attributes %}{{ sidebar_attributes }}{% endif %}>
+            <aside class="civictheme-content__sidebar {% if has_sidebar %}col-m-3 col-xxs-12{% endif %}" role="complementary" {% if sidebar_attributes %}{{ sidebar_attributes }}{% endif %}>
               {{ sidebar }}
             </aside>
           {% endblock %}
         {% endif %}
 
         {% block content %}
-          <section class="civictheme-content__main {% if has_sidebar %}col-m-8 col-m-offset-1{% elseif is_contained %} col-m-12{% endif %}" {% if content_attributes %}{{ content_attributes }}{% endif %}>
+          <section class="civictheme-content__main {% if has_sidebar %}col-m-8 col-m-offset-1 col-xxs-12{% elseif is_contained %} col-m-12 col-xxs-12{% endif %}" {% if content_attributes %}{{ content_attributes }}{% endif %}>
             {{ content }}
           </section>
         {% endblock %}


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [PRJ-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below.

3. CONFLICTS: Make sure that there are no conflicts in your PR. Resolve them before submitting PR for review.

4. COMMENTS: Scan through your PR yourself and comment on the lines that does not look clear enough. This will save SIGNIFICANT time for reviewer to approve the PR.

5. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

6. ASSIGNEE: Assign at least 2 reviewers.     

7. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**Issue URL:** https://salsadigital.atlassian.net/browse/CIVIC-610

### Changed
<!--
Provide a list of what was added/changed/removed etc. 

Start with a verb so that it is clear what has happened:Added/ Updated/Removed/Refactored etc.

Also, explain WHY something was done if this was not a normal implementation.
-->
1.  Added xxs column classes anywhere columns are normally added.
2. Made content align to layout and stretch appropriately to grid.

### Screenshots
**Before**
Content was misaligned and did not stretch correctly to layout

<img width="612" alt="Screen Shot 2022-05-11 at 12 09 48 am" src="https://user-images.githubusercontent.com/520440/167650068-59970657-1d01-4be9-a47f-9bc520302ab5.png">
<img width="612" alt="Screen Shot 2022-05-11 at 12 09 45 am" src="https://user-images.githubusercontent.com/520440/167650096-2fefff5d-ee9a-483a-9c90-51d6e81c93f6.png">
 

**After**
Content aligns neatly and stretched appropriately to width of layout. Content conforms to 320px mobile grid.

<img width="612" alt="Screen Shot 2022-05-11 at 12 09 38 am" src="https://user-images.githubusercontent.com/520440/167650168-dfc50e28-0a8a-4058-83e5-8a5de60f2f58.png">
<img width="612" alt="Screen Shot 2022-05-11 at 12 09 40 am" src="https://user-images.githubusercontent.com/520440/167650203-609ad126-8605-4fb9-b7d5-944eaa42580b.png">


<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
