### PR TITLE
[CIVIC-631] Update listing form rendering for change to core.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme.info.yml
+++ b/docroot/themes/contrib/civictheme/civictheme.info.yml
@@ -576,7 +576,7 @@ config_devel:
     - views.view.civictheme_alerts
     - views.view.civictheme_events
     - views.view.civictheme_listing
-    - views.view.civictheme_views
+    - views.view.civictheme_listing_examples
     - views.view.civictheme_pages
     - webform.webform.civictheme_enquiry
   optional:

--- a/docroot/themes/contrib/civictheme/civictheme.info.yml
+++ b/docroot/themes/contrib/civictheme/civictheme.info.yml
@@ -576,6 +576,7 @@ config_devel:
     - views.view.civictheme_alerts
     - views.view.civictheme_events
     - views.view.civictheme_listing
+    - views.view.civictheme_views
     - views.view.civictheme_pages
     - webform.webform.civictheme_enquiry
   optional:

--- a/docroot/themes/contrib/civictheme/config/install/views.view.civictheme_listing.yml
+++ b/docroot/themes/contrib/civictheme/config/install/views.view.civictheme_listing.yml
@@ -3,14 +3,13 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.civictheme_promo_card
-    - node.type.civictheme_page
     - taxonomy.vocabulary.civictheme_topics
   module:
     - node
     - taxonomy
     - user
 id: civictheme_listing
-label: Civic Theme Listing
+label: 'Civic Theme Listing'
 module: views
 description: ''
 tag: ''
@@ -454,7 +453,7 @@ display:
       defaults:
         use_ajax: false
       use_ajax: false
-      exposed_block: true
+      exposed_block: false
       display_extenders: {  }
     cache_metadata:
       max-age: -1

--- a/docroot/themes/contrib/civictheme/config/install/views.view.civictheme_listing.yml
+++ b/docroot/themes/contrib/civictheme/config/install/views.view.civictheme_listing.yml
@@ -10,7 +10,7 @@ dependencies:
     - taxonomy
     - user
 id: civictheme_listing
-label: Listing
+label: Civic Theme Listing
 module: views
 description: ''
 tag: ''

--- a/docroot/themes/contrib/civictheme/config/install/views.view.civictheme_listing_examples.yml
+++ b/docroot/themes/contrib/civictheme/config/install/views.view.civictheme_listing_examples.yml
@@ -9,8 +9,8 @@ dependencies:
     - node
     - taxonomy
     - user
-id: civictheme_views
-label: 'Civic Theme Example views'
+id: civictheme_listing_examples
+label: 'Civic Theme Example Views'
 module: views
 description: ''
 tag: ''

--- a/docroot/themes/contrib/civictheme/config/install/views.view.civictheme_views.yml
+++ b/docroot/themes/contrib/civictheme/config/install/views.view.civictheme_views.yml
@@ -9,8 +9,8 @@ dependencies:
     - node
     - taxonomy
     - user
-id: civictheme_listing
-label: Listing
+id: civictheme_views
+label: 'Civic Theme Example views'
 module: views
 description: ''
 tag: ''
@@ -445,17 +445,316 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-  civictheme_listing_block:
-    id: civictheme_listing_block
-    display_title: Block
-    display_plugin: block
-    position: 1
+  civictheme_listing_page:
+    id: civictheme_listing_page
+    display_title: 'Complex filter'
+    display_plugin: page
+    position: 2
     display_options:
+      title: 'CivicTheme Large Filter'
       defaults:
-        use_ajax: false
-      use_ajax: false
-      exposed_block: true
+        title: false
+      display_description: 'Multiple filters'
       display_extenders: {  }
+      path: civictheme/listing
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: 'Basic Listing'
+    display_plugin: page
+    position: 2
+    display_options:
+      title: 'CivicTheme Basic Filter'
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            civictheme_page: civictheme_page
+          group: 1
+          exposed: false
+          expose:
+            operator_id: type_op
+            label: 'Content type'
+            description: 'Select a content type to filter by'
+            use_operator: false
+            operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              civictheme_content_author: '0'
+              civictheme_content_approver: '0'
+              civictheme_site_administrator: '0'
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_c_n_topics_target_id:
+          id: field_c_n_topics_target_id
+          table: node__field_c_n_topics
+          field: field_c_n_topics_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_c_n_topics_target_id_op
+            label: Topics
+            description: ' Select a topic to filter by.'
+            use_operator: false
+            operator: field_c_n_topics_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_c_n_topics_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              civictheme_content_author: '0'
+              civictheme_content_approver: '0'
+              civictheme_site_administrator: '0'
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: civictheme_topics
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_tags: {  }
+      defaults:
+        query: false
+        title: false
+        filters: false
+        filter_groups: false
+      display_description: 'Single exposed filter (non-textfield)'
+      display_extenders: {  }
+      path: civictheme/listing-basic
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_2:
+    id: page_2
+    display_title: 'Basic Listing with multiple value'
+    display_plugin: page
+    position: 2
+    display_options:
+      title: 'CivicTheme Basic Filter with Multi-Value'
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            civictheme_page: civictheme_page
+          group: 1
+          exposed: false
+          expose:
+            operator_id: type_op
+            label: 'Content type'
+            description: 'Select a content type to filter by'
+            use_operator: false
+            operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              civictheme_content_author: '0'
+              civictheme_content_approver: '0'
+              civictheme_site_administrator: '0'
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_c_n_topics_target_id:
+          id: field_c_n_topics_target_id
+          table: node__field_c_n_topics
+          field: field_c_n_topics_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_c_n_topics_target_id_op
+            label: Topics
+            description: ' Select a topic to filter by.'
+            use_operator: false
+            operator: field_c_n_topics_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_c_n_topics_target_id
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              civictheme_content_author: '0'
+              civictheme_content_approver: '0'
+              civictheme_site_administrator: '0'
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: civictheme_topics
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_tags: {  }
+      defaults:
+        query: false
+        title: false
+        filters: false
+        filter_groups: false
+      display_description: 'Single exposed filter (non-textfield)'
+      display_extenders: {  }
+      path: civictheme/listing-basic-multi
     cache_metadata:
       max-age: -1
       contexts:

--- a/docroot/themes/contrib/civictheme/includes/listing.inc
+++ b/docroot/themes/contrib/civictheme/includes/listing.inc
@@ -75,17 +75,9 @@ function _civictheme_listing_element(Paragraph $paragraph) {
     $view->initHandlers();
     $element = [];
     // Show exposed form if available for this block display.
-    if ($show_filters) {
-      /** @var \Drupal\views\Plugin\views\exposed_form\ExposedFormPluginInterface $exposed_form */
-      $exposed_form = $view->display_handler->getPlugin('exposed_form');
-      $view->exposed_widgets = $exposed_form->renderExposedForm();
-      // Fixes drupal views bug where if there is a page display within a view
-      // even if you are wanting to render the block view form the action path
-      // of the exposed form points to the page display view.
-      // @see https://www.drupal.org/project/drupal/issues/2844823
-      $view->exposed_widgets['#action'] = Url::fromRoute('<current>')->toString();
-      $view->display_handler->displaysExposed();
-    }
+    $view->civictheme_listing = [
+      'show_filters' => (bool) $show_filters,
+    ];
     $element['view'] = $view->render();
   }
 

--- a/docroot/themes/contrib/civictheme/includes/views.inc
+++ b/docroot/themes/contrib/civictheme/includes/views.inc
@@ -63,6 +63,9 @@ function civictheme_preprocess_views_view(&$variables) {
     $is_view_page ? 'civictheme-listing--with-background' : '',
   ]);
   $variables['modifier_class'] = implode(' ', $variables['modifier_class']);
+  if (isset($view->civictheme_listing['show_filters']) && $view->civictheme_listing['show_filters'] === FALSE) {
+    $variables['exposed'] = NULL;
+  }
 }
 
 /**

--- a/tests/behat/features/paragraph.civictheme_listing.view.feature
+++ b/tests/behat/features/paragraph.civictheme_listing.view.feature
@@ -50,7 +50,7 @@ Feature: Tests the CivicTheme filtering system within blocks and view pages.
     And I should not see an "div.civictheme-listing__body .civictheme-pager" element
     And I should not see an "div.civictheme-listing__body .views-exposed-form" element
 
-  @api @javascript @skipped
+  @api @javascript
   Scenario: CivicTheme listing component should filter pages, update selected filters correctly.
     Given I am an anonymous user
     And "field_c_n_components" in "civictheme_page" "node" with "title" of "[TEST] Page Listing component" has "civictheme_listing" paragraph:


### PR DESCRIPTION
### Issue link: CIVIC-631

### What has changed
1. Drupal core API changed for rendering exposed form separately from view (our listing component does not want this)
2. Turned off exposed form as  a block in listing
3. Deleted listing view pages and moved pages to new view `civictheme_listing_examples`
4. Updated the preprocessing of the view to occur at the view layer rather than paragraph layer

### Screencast of fix

https://user-images.githubusercontent.com/57734756/169940213-347df0df-65aa-435b-ae44-a692b7f8093e.mp4

### To come

With the bigger listing change coming might look at whether we do all parapgraph setting preprocessing in the `civictheme_preprocess_views_view` layer rather than in the paragraph.